### PR TITLE
Update inputman.rs lparam repeat keydown msg

### DIFF
--- a/egui-d3d9/src/inputman.rs
+++ b/egui-d3d9/src/inputman.rs
@@ -18,7 +18,7 @@ use windows::Win32::{
             WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN, WM_MBUTTONUP,
             WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_RBUTTONDBLCLK, WM_RBUTTONDOWN,
             WM_RBUTTONUP, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_XBUTTONDBLCLK, WM_XBUTTONDOWN,
-            WM_XBUTTONUP, XBUTTON1, XBUTTON2,
+            WM_XBUTTONUP, XBUTTON1, XBUTTON2, KF_REPEAT,
         },
     },
 };
@@ -239,7 +239,7 @@ impl InputManager {
                         pressed: true,
                         modifiers,
                         key,
-                        repeat: lparam & 0b1111_1111_1111_1111_0000_0000_0000_0000 > 0,
+                        repeat: lparam & (KF_REPEAT as isize) > 0,
                     });
                 }
                 InputResult::Key


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#previous-key-state-flag

From reading the MSDN docs, this KF_REPEAT keycode should be enough to determine if it is a repeated key msg, for both 64bit LPARAM and 32bit

This would make the crate compile for Win32 too (I hope): ``cargo build --target=i686-pc-windows-msvc``

I am trying to use this library to draw on top of a DirectX9 window from a 32bit proxy d3d9.dll, as I don't want to use C++ & ImGUI anymore, thank you so much for this!

