### PR TITLE
Update windows crate to 0.48.0

### DIFF
--- a/egui-d3d9/Cargo.toml
+++ b/egui-d3d9/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 silent = []
 
 [dependencies]
-windows = { version = "0.44.0", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_System_WindowsProgramming", "Win32_UI_WindowsAndMessaging", "Win32_Graphics_Direct3D_Fxc", "Win32_System_SystemServices", "Win32_Graphics_Dxgi_Common", "Win32_UI_Controls_RichEdit", "Win32_Graphics_Direct3D9", "Win32_System_DataExchange", "Win32_Graphics_Dxgi", "Win32_Graphics_Hlsl", "Win32_System_Memory", "Win32_Foundation", "Foundation_Numerics"] }
+windows = { version = "0.48.0", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_System_WindowsProgramming", "Win32_UI_WindowsAndMessaging", "Win32_Graphics_Direct3D_Fxc", "Win32_System_SystemServices", "Win32_Graphics_Dxgi_Common", "Win32_UI_Controls_RichEdit", "Win32_Graphics_Direct3D9", "Win32_System_DataExchange", "Win32_Graphics_Dxgi", "Win32_Graphics_Hlsl", "Win32_System_Memory", "Win32_Foundation", "Foundation_Numerics"] }
 
 clipboard = "0.5.0"
 egui      = "0.21.0"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.21.0"
 features = ["image"]
 
 [dependencies.windows]
-version = "0.44.0"
+version = "0.48.0"
 features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_Graphics_Dxgi_Common",


### PR DESCRIPTION
Since this crate requires nightly rust anyways, updating makes sense.

I was able to build on nightly 1.71.0 without any warnings. I have not tested the example, but I assume it should all still work the same.