### PR TITLE
Adapt to Rust 2024 edition

### DIFF
--- a/egui-d3d9/Cargo.toml
+++ b/egui-d3d9/Cargo.toml
@@ -8,13 +8,13 @@ repository = "https://github.com/unknowntrojan/egui-d3d9"
 
 # license transferred over from input manager & example
 license = "MIT"
-edition = "2021"
+edition = "2024"
 
 [features]
 silent = []
 
 [dependencies]
-windows = { version = "0.59", features = [
+windows = { version = "0.62.2", features = [
 	"Win32_UI_Input_KeyboardAndMouse",
 	"Win32_System_WindowsProgramming",
 	"Win32_UI_WindowsAndMessaging",
@@ -32,6 +32,7 @@ windows = { version = "0.59", features = [
 	"Wdk_System_SystemInformation",
 ] }
 
+windows-numerics = "0.3.1"
 windows-registry = "0.4.0"
 
 clipboard = "0.5.0"

--- a/egui-d3d9/src/app.rs
+++ b/egui-d3d9/src/app.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 pub struct EguiDx9<T> {
-    ui_fn: Box<dyn FnMut(&Context, &mut T) + 'static>,
+    ui_fn: Box<dyn FnMut(&Context, &mut T) + 'static + Send>,
     ui_state: T,
     hwnd: HWND,
     reactive: bool,
@@ -29,6 +29,8 @@ pub struct EguiDx9<T> {
     should_reset: bool,
 }
 
+unsafe impl<T> Send for EguiDx9<T> {}
+
 impl<T> EguiDx9<T> {
     ///
     /// initialize the backend.
@@ -42,7 +44,7 @@ impl<T> EguiDx9<T> {
     pub fn init(
         dev: &IDirect3DDevice9,
         hwnd: HWND,
-        ui_fn: impl FnMut(&Context, &mut T) + 'static,
+        ui_fn: impl FnMut(&Context, &mut T) + 'static + Send,
         ui_state: T,
         reactive: bool,
     ) -> Self {
@@ -85,7 +87,7 @@ impl<T> EguiDx9<T> {
 
         let output = self.ctx.run(self.input_man.collect_input(), |ctx| {
             // safe. present will never run in parallel.
-            (self.ui_fn)(ctx, &mut self.ui_state)
+            self.ui_fn.as_mut()(ctx, &mut self.ui_state)
         });
 
         if self.should_reset {

--- a/egui-d3d9/src/state.rs
+++ b/egui-d3d9/src/state.rs
@@ -1,5 +1,4 @@
 use windows::{
-    Foundation::Numerics::Matrix4x4,
     Win32::Graphics::Direct3D9::{
         IDirect3DDevice9, IDirect3DStateBlock9, IDirect3DSurface9, D3DBACKBUFFER_TYPE_MONO,
         D3DBLENDOP_ADD, D3DBLEND_INVSRCALPHA, D3DBLEND_ONE, D3DCULL_NONE, D3DFILL_SOLID,
@@ -19,6 +18,7 @@ use windows::{
     },
 };
 
+use windows_numerics::Matrix4x4;
 use crate::mesh::FVF_CUSTOMVERTEX;
 
 pub struct DxState {

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "example-wnd"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["unknowntrojan", "sy1ntexx"]
 description = "Example dll for egui d3d9 showcase."
 license = "MIT"
@@ -23,7 +23,7 @@ version = "0.31"
 features = ["image", "all_loaders"]
 
 [dependencies.windows]
-version = "0.59"
+version = "0.62.2"
 features = [
 	"Win32_UI_WindowsAndMessaging",
 	"Win32_Graphics_Dxgi_Common",

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -10,7 +10,8 @@ use egui::{
 use egui_d3d9::EguiDx9;
 use std::{
     intrinsics::transmute,
-    sync::{Arc, Once},
+    mem::MaybeUninit,
+    sync::{Arc, LazyLock, Mutex, Once, RwLock},
     time::Duration,
 };
 use windows::{
@@ -32,7 +33,7 @@ use windows::{
     },
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "stdcall" fn DllMain(hinst: usize, reason: u32, _reserved: *mut ()) -> i32 {
     if reason == 1 {
         std::thread::spawn(move || unsafe { main_thread(hinst) });
@@ -41,8 +42,8 @@ extern "stdcall" fn DllMain(hinst: usize, reason: u32, _reserved: *mut ()) -> i3
     1
 }
 
-static mut APP: Option<EguiDx9<i32>> = None;
-static mut OLD_WND_PROC: Option<WNDPROC> = None;
+static APP: LazyLock<Mutex<RwLock<MaybeUninit<EguiDx9<i32>>>>> = LazyLock::new(|| Mutex::new(RwLock::new(MaybeUninit::uninit())));
+static OLD_WND_PROC: LazyLock<RwLock<WNDPROC>> = LazyLock::new(|| RwLock::new(None));
 
 static_detour! {
     static PresentHook: unsafe extern "stdcall" fn(IDirect3DDevice9, *const RECT, *const RECT, HWND, *const RGNDATA) -> HRESULT;
@@ -77,18 +78,28 @@ fn hk_present(
             let window = FindWindowA(s!("Valve001"), PCSTR(std::ptr::null()))
                 .expect("unable to find valve window");
 
-            APP = Some(EguiDx9::init(&dev, window, ui, 0, true));
 
-            OLD_WND_PROC = Some(transmute(SetWindowLongPtrA(
-                window,
-                GWLP_WNDPROC,
-                hk_wnd_proc as usize as _,
-            )));
+            {
+                let mut app_writable = APP.lock().unwrap();
+                let mut app_writable = app_writable.get_mut().unwrap();
+                app_writable.write(EguiDx9::init(&dev, window, ui, 0, true));
+            }
+            
+            {
+                let mut old_wnd_proc_writable = OLD_WND_PROC.write().unwrap();
+                *old_wnd_proc_writable = std::mem::transmute(SetWindowLongPtrA(
+                    window,
+                    GWLP_WNDPROC,
+                    hk_wnd_proc as *const() as _,
+                ));
+            }
         });
 
-        APP.as_mut().unwrap().present(&dev);
+        unsafe {
+            APP.try_lock().unwrap().get_mut().unwrap().assume_init_mut().present(&dev);
 
-        PresentHook.call(dev, source_rect, dest_rect, window, rgn_data)
+            PresentHook.call(dev, source_rect, dest_rect, window, rgn_data)
+        }
     }
 }
 
@@ -97,7 +108,7 @@ fn hk_reset(
     presentation_parameters: *const D3DPRESENT_PARAMETERS,
 ) -> HRESULT {
     unsafe {
-        APP.as_mut().unwrap().pre_reset();
+        APP.lock().unwrap().get_mut().unwrap().assume_init_mut().pre_reset();
 
         ResetHook.call(dev, presentation_parameters)
     }
@@ -109,10 +120,32 @@ unsafe extern "stdcall" fn hk_wnd_proc(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
-    APP.as_mut().unwrap().wnd_proc(msg, wparam, lparam);
-
-    CallWindowProcW(OLD_WND_PROC.unwrap(), hwnd, msg, wparam, lparam)
-}
+    // This method is spammed like 60 frames per second (every game frame update) ...
+    unsafe {
+        {
+            // This part usually doesn't crash
+            // This is OLD_WND_PROC that needs special treatment
+            APP.lock().unwrap().get_mut().unwrap().assume_init_mut().wnd_proc(msg, wparam, lparam);
+        }
+        // ... and sometimes, SOMETIMES it pushes two events at the same time making
+        // it freeze unless you handle the lock and skip some of the events.
+        // The "sometimes" means "after you release the mouse button after clicking or dragging someting".
+        // The way to deal with it is to use a structure that allows multiple readers
+        // e.g. RwLock
+        let result = {
+            match OLD_WND_PROC.try_read() {
+                Ok(mut old_wnd_proc) => {
+                    CallWindowProcW(old_wnd_proc.clone(), hwnd, msg, wparam, lparam)
+                },
+                Err(_) => {
+                    println!("Event skipped! hwnd={:?}, msg={:?}, wparam={:?}, lparam={:?}", hwnd, msg, wparam, lparam);
+                    LRESULT(0)
+                }
+            }
+        };
+        
+        result
+    }}
 
 // most of this code is ported over from sy1ntexx's d3d11 implementation.
 static mut FRAME: i32 = 0;
@@ -148,6 +181,7 @@ fn ui(ctx: &Context, i: &mut i32) {
             egui_extras::install_image_loaders(ctx);
         });
 
+        #[allow(static_mut_refs)]
         if TEXT.is_none() {
             TEXT = Some(String::from("Test"));
         }
@@ -188,7 +222,9 @@ fn ui(ctx: &Context, i: &mut i32) {
             }
 
             unsafe {
+                #[allow(static_mut_refs)]
                 ui.checkbox(&mut UI_CHECK, "Some checkbox");
+                #[allow(static_mut_refs)]
                 ui.text_edit_singleline(TEXT.as_mut().unwrap());
                 ScrollArea::vertical().max_height(200.).show(ui, |ui| {
                     for i in 1..=100 {
@@ -196,8 +232,10 @@ fn ui(ctx: &Context, i: &mut i32) {
                     }
                 });
 
+                #[allow(static_mut_refs)]
                 Slider::new(&mut VALUE, -1.0..=1.0).ui(ui);
 
+                #[allow(static_mut_refs)]
                 ui.color_edit_button_rgb(&mut COLOR);
             }
 


### PR DESCRIPTION
So this basically makes it usable with `edition = "2024"` in your `Cargo.toml` file.

Notable changes:
* Updated `windows-rs` crate to `0.62.2`
* Rewrote `static mut: Option<T>` to better fitting alternatives such as `LazyLock<Mutex<RwLock<MaybeUninit<EguiDx9<i32>>>>>` and `LazyLock<RwLock<WNDPROC>>` (for `APP` and `OLD_WND_PROC`). This is made because Rust 2024 prohibits static mutable objects.
* Marked UI statics as `#[allow(static_mut_refs)]` because this part is probably replaced by the users of the lib (I mean they will probably have their own UI implementations).
* Marked `EguiDx9<T>` as unsafe `Send` because otherwise it refused to get shared between (the only) thread.
* Marked the UI function as `+ Send` to properly share between (the only) thread.